### PR TITLE
libzmq2 zmq_poll change

### DIFF
--- a/ZMQ-LibZMQ2/lib/ZMQ/LibZMQ2.pm
+++ b/ZMQ-LibZMQ2/lib/ZMQ/LibZMQ2.pm
@@ -212,6 +212,10 @@ descriptor, so use that to integrate ZMQ::LibZMQ2 and AnyEvent:
         undef $w;
     };
 
+Returns undef on error (and sets $! in that case). Returns an array reference
+containing as many booleans as there are elements in C<@list_of_hashrefs>.
+These booleans indicate whether the socket in question has fired the callback.
+
 =head1 NOTES ON MULTI-PROCESS and MULTI-THREADED USAGE
 
 0MQ works on both multi-process and multi-threaded use cases, but you need

--- a/ZMQ-LibZMQ2/t/005_poll.t
+++ b/ZMQ-LibZMQ2/t/005_poll.t
@@ -12,7 +12,7 @@ subtest 'basic poll with fd' => sub {
         skip "Can't poll using fds on Windows", 2 if ($^O eq 'MSWin32');
         is exception {
             my $called = 0;
-            zmq_poll([
+            my $rv = zmq_poll([
                 {
                     fd       => fileno(STDOUT),
                     events   => ZMQ_POLLOUT,
@@ -20,30 +20,46 @@ subtest 'basic poll with fd' => sub {
                 }
             ], 1);
             ok $called, "callback called";
+            ok(ref($rv) && ref($rv) eq 'ARRAY' && @$rv == 1 && $rv->[0] == $called,
+               "zmq_poll returns an array ref indicating whether the callback was invoked");
         }, undef, "PollItem doesn't die";
     }
 };
 
 subtest 'poll with zmq sockets' => sub {
     my $ctxt = zmq_init();
-    my $req = zmq_socket( $ctxt, ZMQ_REQ );
-    my $rep = zmq_socket( $ctxt, ZMQ_REP );
-    my $called = 0;
+    my $n = 3;
+    my $nsend = 2;
+    my @req = map zmq_socket( $ctxt, ZMQ_REQ ), 1..$n;
+    my @rep = map zmq_socket( $ctxt, ZMQ_REP ), 1..$n;
+    my @called = ((0) x $n);
     is exception {
-        zmq_bind( $rep, "inproc://polltest");
-        zmq_connect( $req, "inproc://polltest");
-        zmq_send( $req, "Test");
+        zmq_bind($rep[$_], "inproc://polltest$_") for 0..$n-1;
+        zmq_connect($req[$_], "inproc://polltest$_") for 0..$n-1;
+        zmq_send( $req[$_], "Test$_") for 0..$nsend-1;
 
-        zmq_poll([
-            {
-                socket   => $rep,
-                events   => ZMQ_POLLIN,
-                callback => sub { $called++ }
-            },
+        my $rv = zmq_poll([
+            map {
+                my $x = $_;
+                +{
+                    socket   => $rep[$x],
+                    events   => ZMQ_POLLIN,
+                    callback => sub { $called[$x]++ }
+                }
+            }
+            (0..$n-1)
         ], 1);
+        my $exp_rv = [((1) x $nsend), ((0) x ($n-$nsend))];
+        is_deeply($rv, $exp_rv,
+                  "zmq_poll returns an array ref indicating whether the callback was invoked");
     }, undef, "PollItem correctly handles callback";
 
-    is $called, 1;
+    for (0..$nsend-1) {
+      is $called[$_], 1;
+    }
+    for ($nsend..$n-1) {
+      is $called[$_], 0;
+    }
 };
 
 done_testing;


### PR DESCRIPTION
It used to return the number of events fired or so. This was not
documented at the Perl wrapper level, just for the plain 0MQ library
call. It's much more useful to get information on WHICH events actually
fired, so this commit changes the return value of the zmq_poll XS to:
- undef if the zmq_poll C call failed (ie. returned -1 previously.
  Now also sets $! from errno, which wasn't the case previously.)
- an array ref if it succeeded. The array ref will contain a 0 or 1 for
  each socket in the poll list. 0 indicates that there was no event for
  the given socket, 1 indicates that there was.
