### PR TITLE
Two useful functions add to ZMQ::CZMQ binding: zsocket_poll zmsg_dump

### DIFF
--- a/ZMQ-CZMQ/lib/ZMQ/CZMQ.pm
+++ b/ZMQ-CZMQ/lib/ZMQ/CZMQ.pm
@@ -38,6 +38,7 @@ our %EXPORT_OK = (
         zmsg_decode
         zmsg_destroy
         zmsg_dup
+        zmsg_dump
         zmsg_encode
         zmsg_first
         zmsg_last

--- a/ZMQ-CZMQ/xs/perl_czmq.xs
+++ b/ZMQ-CZMQ/xs/perl_czmq.xs
@@ -455,5 +455,8 @@ zmsg_dup(msg)
     PREINIT:
         SV *class_sv = sv_2mortal(newSVpv("ZMQ::CZMQ::zmsg", 0));
 
+void
+zmsg_dump(msg)
+        PerlCZMQ_zmsg *msg;
 
 


### PR DESCRIPTION
Hello.
I have added bindings for two functions of czmq library: 
Bool zsocket_poll($socket, $msecs)
void zmsg_dump($msg)

The last one very handy for debugging.
