### PR TITLE
Checking for the wrong version of the 0mq library when installing LibZMQ3

### DIFF
--- a/ZMQ-LibZMQ3/tools/detect_zmq.pl
+++ b/ZMQ-LibZMQ3/tools/detect_zmq.pl
@@ -77,11 +77,6 @@ sub probe_pkgconfig {
 
         print " + found $pkg $version\n";
 
-        my ($major, $minor, $micro) = split /\./, $version;
-        if ( $major != 2 && $minor != 1 ) {
-            die "Whoa there! We don't support anything other than libzmq 2.1.x";
-        }
-
         if (! $ENV{ZMQ_INCLUDES}) {
             if (my $cflags = qx/$pkg_config --cflags-only-I $pkg/) {
                 chomp $cflags;


### PR DESCRIPTION
tools/detect_zmq.pl checks the libzmq version if it uses pkg-config to detect 0MQ. It is checking for version 2.1.x rather than 3.

The tests bypass the problem as they always set ZMQ_H.

I'm pretty sure the check isn't needed as Makefile.PL already checks for version 3 or greater.
