### PR TITLE
Fixed zmq_msg_recv() documentation in ZMQ::LibZMQ3

### DIFF
--- a/ZMQ-LibZMQ3/lib/ZMQ/LibZMQ3.pm
+++ b/ZMQ-LibZMQ3/lib/ZMQ/LibZMQ3.pm
@@ -503,8 +503,11 @@ every time.
 =head2 $rv = zmq_msg_recv($msg, $sock, $flags)
 
 Receives a new message from C<$sock>, and writes the new content to C<$msg>.
-Argument C<$flags> may be omitted. Returns 0 upon success, -1 on failure and
-sets $!.
+Argument C<$flags> may be omitted.
+
+Returns the number of bytes in the message if successful.
+
+Returns -1 upon failure, and sets $!.
 
 Other than the fact that libzmq has deprecated C<zmq_recvmsg()>, this
 construct is useful if you don't want to allocate a message struct for


### PR DESCRIPTION
Patch for issue #52: ZMQ::LibZMQ3 documentation is wrong for zmq_zmg_recv()
