### PR TITLE
200_fork.t panics on Windows

### DIFF
--- a/ZMQ-LibZMQ3/t/200_fork.t
+++ b/ZMQ-LibZMQ3/t/200_fork.t
@@ -35,6 +35,9 @@ subtest 'parent creates context, socket, and forks, child does nothing' => sub {
 };
 
 subtest 'parent creates context, socket, and forks, child calls zmq_close()' => sub {
+
+    plan skip_all => 'perl panics on Windows' if $^O eq 'MSWin32';
+
     my $ctx = zmq_init(1);
     my $sock = zmq_socket($ctx, ZMQ_REQ);
     my $pid = fork();


### PR DESCRIPTION
At least with Strawberry Perl 5.20 on Windows 7 x64. The message is:

```
panic: attempt to copy freed scalar 23bad200 to 22bad28 at {something}/perl/lib/Test/Builder.pm line 2366.
```
