### PR TITLE
socket object be examined more safety in zmq_poll().

### DIFF
--- a/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
+++ b/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
@@ -1067,6 +1067,8 @@ P5ZMQ3_zmq_poll( list, timeout = 0 )
                     croak("Invalid 'socket' given for index %d", i);
                 }
                 mg = P5ZMQ3_Socket_mg_find( aTHX_ SvRV(*svr), &P5ZMQ3_Socket_vtbl );
+                if (mg->mg_ptr == NULL)
+                    continue;
                 pollitems[i].socket = ((P5ZMQ3_Socket *) mg->mg_ptr)->socket;
                 P5ZMQ3_TRACE( " + via pollitem[%d].socket = %p", i, pollitems[i].socket );
             } else {

--- a/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
+++ b/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
@@ -1067,8 +1067,10 @@ P5ZMQ3_zmq_poll( list, timeout = 0 )
                     croak("Invalid 'socket' given for index %d", i);
                 }
                 mg = P5ZMQ3_Socket_mg_find( aTHX_ SvRV(*svr), &P5ZMQ3_Socket_vtbl );
-                if (mg->mg_ptr == NULL)
+                if (mg->mg_ptr == NULL) {
+                    warn("Invalid socket found with pollitems[%i] in zmq_poll(), ignoring", i);
                     continue;
+                }
                 pollitems[i].socket = ((P5ZMQ3_Socket *) mg->mg_ptr)->socket;
                 P5ZMQ3_TRACE( " + via pollitem[%d].socket = %p", i, pollitems[i].socket );
             } else {


### PR DESCRIPTION
Hi, It's been a long time :-)

When I use `zmq_poll()`, It falls to segmentation fault.

Interestingly, that situation not always.

so I have traced this code with GDB, I met this situation like that.

```
Program received signal SIGSEGV, Segmentation fault.
0x00007fffee1fec62 in XS_ZMQ__LibZMQ3_zmq_poll (my_perl=<value optimized out>, cv=<value optimized out>) at xs/perl_libzmq3.xs:1070
1070                    pollitems[i].socket = ((P5ZMQ3_Socket *) mg->mg_ptr)->socket;
```

I have put this code into the `xs/perl_libzmq3.xs`

```
1070                 printf("ADDR: %#X\n", mg->mg_ptr);
1071                 pollitems[i].socket = ((P5ZMQ3_Socket *) mg->mg_ptr)->socket;
```

and then I have seen this results.

**Normal case**
```
[INFO] Initializing...
[New Thread 0x7fffed024700 (LWP 28015)]
[New Thread 0x7fffec623700 (LWP 28016)]
[INFO] Request: tcp://127.0.0.1:6547
ADDR: 0X18ACCA0
ADDR: 0X1CD1AC0
...
ADDR: 0X18ACCA0
ADDR: 0X1CD1AC0
ADDR: 0X18A67B0

Program received signal SIGQUIT, Quit.
0x00007ffff7b19e30 in Perl_pp_nextstate () from /usr/lib64/perl5/CORE/libperl.so
(gdb) c
Continuing.
[Thread 0x7fffed024700 (LWP 28015) exited]
[Thread 0x7fffec623700 (LWP 28016) exited]
[INFO] worker has stopped.
[DEBUG] Testers: [
  {
    'Connected' => 1,
    'Address' => 'tcp://127.0.0.1:6547',
  }
]
[INFO] Stopped and terminated succesfully.

Program exited normally.
(gdb)
```

**Fault case**
```
[INFO] Initializing...
[New Thread 0x7fffed024700 (LWP 29319)]
[New Thread 0x7fffec623700 (LWP 29320)]
[INFO] Request to the monitor for registering: tcp://127.0.0.1:6547
ADDR: 0X18ACCA0
ADDR: 0X1CD1AC0
...
ADDR: 0X18ACCA0
ADDR: 0X1CD1AC0
ADDR: 0X18A67B0

Program received signal SIGQUIT, Quit.
0x00007ffff7b2ad20 in Perl_sv_clear () from /usr/lib64/perl5/CORE/libperl.so
(gdb) c
Continuing.
[Thread 0x7fffec623700 (LWP 29330) exited]
[Thread 0x7fffed024700 (LWP 29329) exited]
[INFO] worker has stopped.
ADDR: 0

Program received signal SIGSEGV, Segmentation fault.
0x00007fffee1fe68f in XS_ZMQ__LibZMQ3_zmq_poll (my_perl=<value optimized out>, cv=<value optimized out>) at xs/perl_libzmq3.xs:1071
1071                    pollitems[i].socket = ((P5ZMQ3_Socket *) mg->mg_ptr)->socket;

(gdb) bt
#0  0x00007fffee1fe68f in XS_ZMQ__LibZMQ3_zmq_poll (my_perl=<value optimized out>, cv=<value optimized out>) at xs/perl_libzmq3.xs:>
#1  0x00007ffff7b18815 in Perl_pp_entersub () from /usr/lib64/perl5/CORE/libperl.so
#2  0x00007ffff7b16b06 in Perl_runops_standard () from /usr/lib64/perl5/CORE/libperl.so
#3  0x00007ffff7abf0d8 in perl_run () from /usr/lib64/perl5/CORE/libperl.so
#4  0x0000000000400e74 in main (argc=2, argv=0x7fffffffe338, env=0x7fffffffe350) at perlmain.c:117
```

I'm guessing that is caused by calling `zmq_poll()` in a thread whereas calling `zmq_close(), zmq_term()` finished in another thread.

so I'm trying to solve that like that... :-)

I want you will have a nice day!