### PR TITLE
tests depend on Test::SharedFork explicitly

### DIFF
--- a/ZMQ-LibZMQ2/Makefile.PL
+++ b/ZMQ-LibZMQ2/Makefile.PL
@@ -42,6 +42,7 @@ requires 'ZMQ::Constants', '1.00';
 test_requires 'Test::More', '0.98';
 test_requires 'Test::TCP' => '1.08';
 test_requires 'Test::Requires';
+test_requires 'Test::SharedFork';
 test_requires 'Test::Fatal';
 use_xshelper '-clean';
 

--- a/ZMQ-LibZMQ3/Makefile.PL
+++ b/ZMQ-LibZMQ3/Makefile.PL
@@ -79,6 +79,7 @@ requires 'ZMQ::Constants';
 test_requires 'Test::More', '0.98';
 test_requires 'Test::TCP' => '1.08';
 test_requires 'Test::Requires';
+test_requires 'Test::SharedFork';
 test_requires 'Test::Fatal';
 use_xshelper '-clean';
 


### PR DESCRIPTION
It seems that tests require Test::SharedFork to work, but it is not explicitly declared. Everything worked, because Test::TCP requires Test::SharedFork, and Test::TCP is an official dependency.