### PR TITLE
add use warnings; to *.pm files

### DIFF
--- a/ZMQ-CZMQ/lib/ZMQ/CZMQ.pm
+++ b/ZMQ-CZMQ/lib/ZMQ/CZMQ.pm
@@ -1,4 +1,5 @@
 package ZMQ::CZMQ;
+use warnings;
 use strict;
 our $VERSION = '1.04';
 our $BACKEND;

--- a/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zctx.pm
+++ b/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zctx.pm
@@ -1,4 +1,5 @@
 package ZMQ::CZMQ::Zctx;
+use warnings;
 use strict;
 use ZMQ::CZMQ;
 

--- a/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zframe.pm
+++ b/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zframe.pm
@@ -1,4 +1,5 @@
 package ZMQ::CZMQ::Zframe;
+use warnings;
 use strict;
 use ZMQ::CZMQ;
 use Scalar::Util ();

--- a/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zmsg.pm
+++ b/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zmsg.pm
@@ -1,4 +1,5 @@
 package ZMQ::CZMQ::Zmsg;
+use warnings;
 use strict;
 use ZMQ::CZMQ;
 

--- a/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zsocket.pm
+++ b/ZMQ-CZMQ/lib/ZMQ/CZMQ/Zsocket.pm
@@ -1,4 +1,5 @@
 package ZMQ::CZMQ::Zsocket;
+use warnings;
 use strict;
 use ZMQ::CZMQ;
 use Scalar::Util ();

--- a/ZMQ-Constants/lib/ZMQ/Constants.pm
+++ b/ZMQ-Constants/lib/ZMQ/Constants.pm
@@ -1,4 +1,5 @@
 package ZMQ::Constants;
+use warnings;
 use strict;
 use base qw(Exporter);
 use Carp ();

--- a/ZMQ-Constants/lib/ZMQ/Constants/V2_1_11.pm
+++ b/ZMQ-Constants/lib/ZMQ/Constants/V2_1_11.pm
@@ -1,4 +1,5 @@
 package ZMQ::Constants::V2_1_11;
+use warnings;
 use strict;
 use Storable ();
 use ZMQ::Constants ();

--- a/ZMQ-Constants/lib/ZMQ/Constants/V3_1_1.pm
+++ b/ZMQ-Constants/lib/ZMQ/Constants/V3_1_1.pm
@@ -1,4 +1,5 @@
 package ZMQ::Constants::V3_1_1;
+use warnings;
 use strict;
 use ZMQ::Constants ();
 use Storable ();

--- a/ZMQ-Constants/lib/ZMQ/Constants/V3_1_2.pm
+++ b/ZMQ-Constants/lib/ZMQ/Constants/V3_1_2.pm
@@ -1,4 +1,5 @@
 package ZMQ::Constants::V3_1_2;
+use warnings;
 use strict;
 use ZMQ::Constants ();
 use Storable ();

--- a/ZMQ-Constants/lib/ZMQ/Constants/V4_0_4.pm
+++ b/ZMQ-Constants/lib/ZMQ/Constants/V4_0_4.pm
@@ -1,4 +1,5 @@
 package ZMQ::Constants::V4_0_4;
+use warnings;
 use strict;
 use ZMQ::Constants ();
 use Storable       ();

--- a/ZMQ-LibCZMQ1/lib/ZMQ/LibCZMQ1.pm
+++ b/ZMQ-LibCZMQ1/lib/ZMQ/LibCZMQ1.pm
@@ -1,4 +1,5 @@
 package ZMQ::LibCZMQ1;
+use warnings;
 use strict;
 use Exporter 'import';
 use XSLoader;

--- a/ZMQ-LibZMQ2/lib/ZMQ/LibZMQ2.pm
+++ b/ZMQ-LibZMQ2/lib/ZMQ/LibZMQ2.pm
@@ -1,4 +1,5 @@
 package ZMQ::LibZMQ2;
+use warnings;
 use strict;
 use base qw(Exporter);
 use XSLoader;

--- a/ZMQ-LibZMQ3/lib/ZMQ/LibZMQ3.pm
+++ b/ZMQ-LibZMQ3/lib/ZMQ/LibZMQ3.pm
@@ -1,4 +1,5 @@
 package ZMQ::LibZMQ3;
+use warnings;
 use strict;
 use warnings;
 use base qw(Exporter);

--- a/ZMQ-LibZMQ4/inc/Devel/CheckLib.pm
+++ b/ZMQ-LibZMQ4/inc/Devel/CheckLib.pm
@@ -1,4 +1,5 @@
 # $Id: CheckLib.pm,v 1.25 2008/10/27 12:16:23 drhyde Exp $
+use warnings;
 
 package #
 Devel::CheckLib;

--- a/ZMQ-LibZMQ4/inc/Module/Install.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install;
 
 # For any maintainers:

--- a/ZMQ-LibZMQ4/inc/Module/Install/AuthorTests.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/AuthorTests.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::AuthorTests;
 
 use 5.005;

--- a/ZMQ-LibZMQ4/inc/Module/Install/Base.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/Base.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::Base;
 
 use strict 'vars';

--- a/ZMQ-LibZMQ4/inc/Module/Install/Can.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/Can.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::Can;
 
 use strict;

--- a/ZMQ-LibZMQ4/inc/Module/Install/CheckLib.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/CheckLib.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::CheckLib;
 
 use strict;

--- a/ZMQ-LibZMQ4/inc/Module/Install/Fetch.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/Fetch.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::Fetch;
 
 use strict;

--- a/ZMQ-LibZMQ4/inc/Module/Install/Makefile.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/Makefile.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::Makefile;
 
 use strict 'vars';

--- a/ZMQ-LibZMQ4/inc/Module/Install/Metadata.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/Metadata.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::Metadata;
 
 use strict 'vars';

--- a/ZMQ-LibZMQ4/inc/Module/Install/Win32.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/Win32.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::Win32;
 
 use strict;

--- a/ZMQ-LibZMQ4/inc/Module/Install/WriteAll.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/WriteAll.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::WriteAll;
 
 use strict;

--- a/ZMQ-LibZMQ4/inc/Module/Install/XSUtil.pm
+++ b/ZMQ-LibZMQ4/inc/Module/Install/XSUtil.pm
@@ -1,4 +1,5 @@
 #line 1
+use warnings;
 package Module::Install::XSUtil;
 
 use 5.005_03;

--- a/ZMQ-LibZMQ4/lib/ZMQ/LibZMQ4.pm
+++ b/ZMQ-LibZMQ4/lib/ZMQ/LibZMQ4.pm
@@ -1,4 +1,5 @@
 package ZMQ::LibZMQ4;
+use warnings;
 use strict;
 use warnings;
 use base qw(Exporter);

--- a/ZMQ/lib/ZMQ.pm
+++ b/ZMQ/lib/ZMQ.pm
@@ -1,4 +1,5 @@
 package ZMQ;
+use warnings;
 use strict;
 our $VERSION = '1.06';
 our $BACKEND;

--- a/ZMQ/lib/ZMQ/Context.pm
+++ b/ZMQ/lib/ZMQ/Context.pm
@@ -1,4 +1,5 @@
 package ZMQ::Context;
+use warnings;
 use strict;
 use ZMQ::Socket;
 

--- a/ZMQ/lib/ZMQ/Message.pm
+++ b/ZMQ/lib/ZMQ/Message.pm
@@ -1,4 +1,5 @@
 package ZMQ::Message;
+use warnings;
 use strict;
 use Sub::Name ();
 

--- a/ZMQ/lib/ZMQ/Poller.pm
+++ b/ZMQ/lib/ZMQ/Poller.pm
@@ -1,4 +1,5 @@
 package ZMQ::Poller;
+use warnings;
 use strict;
 
 use ZMQ;

--- a/ZMQ/lib/ZMQ/Serializer.pm
+++ b/ZMQ/lib/ZMQ/Serializer.pm
@@ -1,4 +1,5 @@
 package ZMQ::Serializer;
+use warnings;
 use strict;
 use ZMQ;
 use ZMQ::Socket;

--- a/ZMQ/lib/ZMQ/Socket.pm
+++ b/ZMQ/lib/ZMQ/Socket.pm
@@ -1,4 +1,5 @@
 package ZMQ::Socket;
+use warnings;
 use strict;
 use ZMQ;
 use ZMQ::Constants qw/ZMQ_SNDMORE ZMQ_RCVMORE/;


### PR DESCRIPTION
according to
http://cpants.cpanauthors.org/dist/ZMQ-LibZMQ2
module does not have use warnings; 
I think that it's wrong
also Neil Bowers #pr-challenge push me to think about improve this distribution