### PR TITLE
Include stdint.h install ZMQ-LibZMQ3 in strawberry perl

### DIFF
--- a/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
+++ b/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
@@ -1,4 +1,5 @@
 #include "perl_libzmq3.h"
+#include <stdint.h>
 
 STATIC_INLINE
 void


### PR DESCRIPTION
The inclusion of <stdint.h> alow the compilation of ZMQ::LibZMQ3 in strawberry perl for Windows.
It also keeps the correct Unix System's compilation as it is a standard library: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/stdint.h.html
The errors taken place in strawberry perl without this include were:
xs\\perl_libzmq3.xs:36:5: error: unknown type name 'int64_t'
