### PR TITLE
add xsreturn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: perl
 perl:
   - "5.20"
   - "5.22"
+  - "5.24"
 install: "perl -e 1" # dummy
 script: "perl ./.TRAVIS.PL"
 sudo: false

--- a/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
+++ b/ZMQ-LibZMQ3/xs/perl_libzmq3.xs
@@ -1140,6 +1140,12 @@ P5ZMQ3_zmq_poll( list, timeout = 0 )
         Safefree(pollitems);
         Safefree(callbacks);
         P5ZMQ3_TRACE( "END zmq_poll" );
+        if (GIMME_V == G_SCALAR) {
+            XSRETURN(1);
+        } else {
+            XSRETURN(list_len);
+        }
+
 
 int
 P5ZMQ3_zmq_device( device, insocket, outsocket )


### PR DESCRIPTION
ZMQ::LibZMQ3::zmq_poll cannot return the valid `rv` in scalar environment on perl v5.24 on my code. But I cannot  construct a test case for it. Anyway, it is ok after I added XSRETURN.
