### PR TITLE
Fix rpath handling on macOS and test macOS on TravisCI

### DIFF
--- a/.TRAVIS.PL
+++ b/.TRAVIS.PL
@@ -53,6 +53,13 @@ sub install_libzmq(@) {
     return $prefix;
 }
 
+sub setup_cpanm_local_lib {
+    cpanm(qw(--local-lib=~/perl5 local::lib));
+    push @INC, "$ENV{HOME}/perl5/lib/perl5";
+    require local::lib;
+    local::lib->setup_env_hash_for("$ENV{HOME}/perl5");
+}
+
 sub cpanm (@) {
     eval {
         mysystem("cpanm", "--notest", @_);
@@ -87,6 +94,14 @@ sub install_libczmq {
             sprintf('--with-libzmq=%s', File::Spec->catdir($EXTDIR, "zeromq-$zmq_version")),
         ]
     });
+}
+
+if( $^O eq 'darwin' ) {
+    mysystem(qw(brew install cpanm));
+    setup_cpanm_local_lib;
+
+    # set ARCHFLAGS so that `-arch i386` is not tried
+    $ENV{ARCHFLAGS} = '-arch x86_64';
 }
 
 if ( $target eq 'ZMQ-Constants' ) {

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: perl
+matrix:
+  include:
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-Constants" }
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-CZMQ" }
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibCZMQ1" }
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ2" }
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ3" }
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ4" }
+    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ" }
 perl:
   - "5.20"
   - "5.22"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ matrix:
     - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-Constants" }
     - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-CZMQ" }
     - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibCZMQ1" }
-    - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ2" }
+
+    # The `xt/102_eg_threaded.t` test hangs under this configuration.
+    #- { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ2" }
+
     - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ3" }
     - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ-LibZMQ4" }
     - { perl: "system", os: "osx", env: "PERL_ZMQ_TEST_TARGET=ZMQ" }

--- a/ZMQ-LibZMQ3/Makefile.PL
+++ b/ZMQ-LibZMQ3/Makefile.PL
@@ -203,11 +203,13 @@ if ($^O eq 'darwin' && -f "Makefile") {
 
     local @ARGV = qw(Makefile);
     local $^I = '';
+    my @lib_paths = grep { -d $_ } map { s/^-L//; $_ } split /\s+/, $ENV{ZMQ_LIBS};
+    my $lib_rpaths = join ",", @lib_paths;
     while (<>) {
         if ($^O eq 'darwin') {
             s/MACOSX_DEPLOYMENT_TARGET=(\d+\.\d+)/$1 < 10.5 ? "MACOSX_DEPLOYMENT_TARGET=$version" : "MACOSX_DEPLOYMENT_TARGET=$1"/e;
         }
-        s/OTHERLDFLAGS =\s*$/OTHERLDFLAGS = -Wl,-rpath $ENV{ZMQ_LIBS}\n/;
+        s/OTHERLDFLAGS =\s*$/OTHERLDFLAGS = -Wl,-rpath,$lib_rpaths\n/;
         print;
     }
 }

--- a/ZMQ-LibZMQ4/Makefile.PL
+++ b/ZMQ-LibZMQ4/Makefile.PL
@@ -202,11 +202,13 @@ if ($^O eq 'darwin' && -f "Makefile") {
 
     local @ARGV = qw(Makefile);
     local $^I = '';
+    my @lib_paths = grep { -d $_ } map { s/^-L//; $_ } split /\s+/, $ENV{ZMQ_LIBS};
+    my $lib_rpaths = join ",", @lib_paths;
     while (<>) {
         if ($^O eq 'darwin') {
             s/MACOSX_DEPLOYMENT_TARGET=(\d+\.\d+)/$1 < 10.5 ? "MACOSX_DEPLOYMENT_TARGET=$version" : "MACOSX_DEPLOYMENT_TARGET=$1"/e;
         }
-        s/OTHERLDFLAGS =\s*$/OTHERLDFLAGS = -Wl,-rpath $ENV{ZMQ_LIBS}\n/;
+        s/OTHERLDFLAGS =\s*$/OTHERLDFLAGS = -Wl,-rpath,$lib_rpaths\n/;
         print;
     }
 }


### PR DESCRIPTION
Instead of using the entire contents of `$ENV{ZMQ_LIBS}`, this only uses
the linker paths (`-L`).

Inserting the rpath was done correctly before at
<https://github.com/lestrrat/p5-ZMQ/commit/0b42da62f401fd1d4d83aabe9d933b517e803a98>.
